### PR TITLE
Update auth tokens to return both accessToken and refreshToken

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -16,7 +16,8 @@ export class AuthController {
   @Post('login')
   @UseGuards(LocalGuard)
   async login(@Req() req: Request) {
-    const tokens = await this.authService.generateTokens(req.user);
+    const user = await this.authService.validateUser(req.body);
+    const tokens = await this.authService.generateTokens(user);
     return tokens;
   }
 
@@ -35,7 +36,8 @@ export class AuthController {
 
   @Post('refresh')
   @UseGuards(RefreshGuard)
-  refresh(@Body() refreshDto: RefreshDto) {
-    return this.authService.refreshToken(refreshDto.refreshToken);
+  async refresh(@Body() refreshDto: RefreshDto) {
+    const tokens = await this.authService.refreshToken(refreshDto.refreshToken);
+    return tokens;
   }
 }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -32,7 +32,7 @@ describe('AuthService', () => {
   });
 
   describe('refreshToken', () => {
-    it('should return a new access token', async () => {
+    it('should return a new access token and refresh token', async () => {
       const refreshToken = 'test-refresh-token';
       const user = { id: 1, username: 'testuser', password: 'testpassword' };
       const payload = { id: user.id };
@@ -98,6 +98,46 @@ describe('AuthService', () => {
         { id: user.id, username: user.username },
         { secret: 'refreshSecretKey', expiresIn: '7d' },
       );
+    });
+  });
+
+  describe('validateUser', () => {
+    it('should return the user object if the username and password are correct', async () => {
+      const username = 'testuser';
+      const password = 'testpassword';
+      const user = { id: 1, username, password };
+
+      jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(user as User);
+
+      const result = await service.validateUser({ username, password });
+
+      expect(result).toEqual(user);
+      expect(userRepository.findOneBy).toHaveBeenCalledWith({ username });
+    });
+
+    it('should return null if the username is incorrect', async () => {
+      const username = 'wronguser';
+      const password = 'testpassword';
+
+      jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(null);
+
+      const result = await service.validateUser({ username, password });
+
+      expect(result).toBeNull();
+      expect(userRepository.findOneBy).toHaveBeenCalledWith({ username });
+    });
+
+    it('should return null if the password is incorrect', async () => {
+      const username = 'testuser';
+      const password = 'wrongpassword';
+      const user = { id: 1, username, password: 'testpassword' };
+
+      jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(user as User);
+
+      const result = await service.validateUser({ username, password });
+
+      expect(result).toBeNull();
+      expect(userRepository.findOneBy).toHaveBeenCalledWith({ username });
     });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -17,8 +17,7 @@ export class AuthService {
     if (!findUser) return null;
 
     if (password === findUser.password) {
-      const tokens = this.generateTokens(findUser);
-      return tokens;
+      return findUser;
     }
   }
 


### PR DESCRIPTION
Update authentication service and controller to return both accessToken and refreshToken

* **auth.service.ts**
  - Update `refreshToken` method to return both `accessToken` and `refreshToken`
  - Update `validateUser` method to return user object instead of tokens

* **auth.controller.ts**
  - Update `login` method to call `authService.validateUser` and then `authService.generateTokens`
  - Update `refresh` method to return both `accessToken` and `refreshToken`

* **auth.service.spec.ts**
  - Update `refreshToken` test to check for both `accessToken` and `refreshToken`
  - Add tests for `validateUser` method to check for user object instead of tokens

* **auth.controller.spec.ts**
  - Update `login` test to call `authService.validateUser` and then `authService.generateTokens`
  - Update `refresh` test to check for both `accessToken` and `refreshToken`

